### PR TITLE
Added an s to match the actual api... lol

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
     flag.Parse()
     client := vt.NewClient("<apikey>")
 
-    file, err := client.GetObject(vt.URL("file/%s", sha256));
+    file, err := client.GetObject(vt.URL("files/%s", sha256));
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
simple... but could quicken troubleshooting for noobs if they don't take the time to look at the vt documentation.