### PR TITLE
make objectData.ID an int to match API

### DIFF
--- a/object.go
+++ b/object.go
@@ -23,7 +23,7 @@ import (
 // objectData is the structure that have the data returned by the API for an
 // object.
 type objectData struct {
-	ID                string                       `json:"id,omitempty"`
+	ID                int                          `json:"id,omitempty"`
 	Type              string                       `json:"type,omitempty"`
 	Attributes        map[string]interface{}       `json:"attributes,omitempty"`
 	ContextAttributes map[string]interface{}       `json:"context_attributes,omitempty"`
@@ -54,7 +54,7 @@ func NewObject(objType string) *Object {
 }
 
 // NewObjectWithID creates a new object with the specified ID.
-func NewObjectWithID(objType, id string) *Object {
+func NewObjectWithID(objType string, id int) *Object {
 	return &Object{data: objectData{
 		Type:       objType,
 		ID:         id,
@@ -62,7 +62,7 @@ func NewObjectWithID(objType, id string) *Object {
 }
 
 // ID returns the object's identifier.
-func (obj *Object) ID() string {
+func (obj *Object) ID() int {
 	return obj.data.ID
 }
 
@@ -133,7 +133,7 @@ func (obj *Object) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(v.Data, &o); err == nil {
 			v.IsOneToOne = true
 			// If the value is null the Object will have an empty ID and Type.
-			if o.data.ID == "" && o.data.Type == "" {
+			if o.data.ID == 0 && o.data.Type == "" {
 				v.Objects = nil
 			} else {
 				v.Objects = append(v.Objects, &o)

--- a/vt_test.go
+++ b/vt_test.go
@@ -71,7 +71,7 @@ func TestGetObject(t *testing.T) {
 		SetResponse(map[string]interface{}{
 			"data": map[string]interface{}{
 				"type": "object_type",
-				"id":   "object_id",
+				"id":   123,
 				"attributes": map[string]interface{}{
 					"some_int":    1,
 					"some_string": "hello",
@@ -92,7 +92,7 @@ func TestGetObject(t *testing.T) {
 	o, err := c.GetObject(vt.URL("/collection/object_id"))
 
 	assert.NoError(t, err)
-	assert.Equal(t, "object_id", o.ID())
+	assert.Equal(t, 123, o.ID())
 	assert.Equal(t, "object_type", o.Type())
 
 	s, err := o.Get("some_string")
@@ -154,7 +154,7 @@ func TestPostObject(t *testing.T) {
 		SetResponse(map[string]interface{}{
 			"data": map[string]interface{}{
 				"type": "object_type",
-				"id":   "object_id",
+				"id":   123,
 				"attributes": map[string]interface{}{
 					"some_string": "hello",
 				},
@@ -169,7 +169,7 @@ func TestPostObject(t *testing.T) {
 	err := c.PostObject(vt.URL("/collection"), o)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "object_id", o.ID())
+	assert.Equal(t, 123, o.ID())
 	assert.Equal(t, "object_type", o.Type())
 	assert.Equal(t, "hello", o.MustGetString("some_string"))
 }
@@ -181,7 +181,7 @@ func TestPatchObject(t *testing.T) {
 		SetResponse(map[string]interface{}{
 			"data": map[string]interface{}{
 				"type": "object_type",
-				"id":   "object_id",
+				"id":   123,
 				"attributes": map[string]interface{}{
 					"some_string": "hello",
 					"some_int":    1,
@@ -195,7 +195,7 @@ func TestPatchObject(t *testing.T) {
 		SetResponse(map[string]interface{}{
 			"data": map[string]interface{}{
 				"type": "object_type",
-				"id":   "object_id",
+				"id":   123,
 				"attributes": map[string]interface{}{
 					"some_string": "hello",
 				},
@@ -207,14 +207,14 @@ func TestPatchObject(t *testing.T) {
 	c := vt.NewClient("api_key")
 
 	vt.SetHost(getServer.URL)
-	o, err := c.GetObject(vt.URL("/collection/object_id"))
+	o, err := c.GetObject(vt.URL("/collection/123"))
 
 	vt.SetHost(patchServer.URL)
 	o.SetString("some_string", "world")
-	err = c.PatchObject(vt.URL("/collection/object_id"), o)
+	err = c.PatchObject(vt.URL("/collection/123"), o)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "object_id", o.ID())
+	assert.Equal(t, 123, o.ID())
 	assert.Equal(t, "object_type", o.Type())
 	assert.Equal(t, "hello", o.MustGetString("some_string"))
 }
@@ -227,7 +227,7 @@ func TestIterator(t *testing.T) {
 			"data": []map[string]interface{}{
 				{
 					"type": "object_type",
-					"id":   "object_id_1",
+					"id":   1000,
 					"attributes": map[string]interface{}{
 						"some_string": "hello",
 					},
@@ -237,7 +237,7 @@ func TestIterator(t *testing.T) {
 				},
 				{
 					"type": "object_type",
-					"id":   "object_id_2",
+					"id":   2000,
 					"attributes": map[string]interface{}{
 						"some_string": "world",
 					},
@@ -257,11 +257,11 @@ func TestIterator(t *testing.T) {
 	assert.NoError(t, it.Error())
 
 	assert.True(t, it.Next())
-	assert.Equal(t, "object_id_1", it.Get().ID())
+	assert.Equal(t, 1000, it.Get().ID())
 	s, _ := it.Get().GetContextString("some_string")
 	assert.Equal(t, "foo", s)
 	assert.True(t, it.Next())
-	assert.Equal(t, "object_id_2", it.Get().ID())
+	assert.Equal(t, 2000, it.Get().ID())
 	s, _ = it.Get().GetContextString("some_string")
 	assert.Equal(t, "bar", s)
 	assert.False(t, it.Next())
@@ -275,7 +275,7 @@ func TestIteratorSingleObject(t *testing.T) {
 		SetResponse(map[string]interface{}{
 			"data": map[string]interface{}{
 				"type": "object_type",
-				"id":   "object_id",
+				"id":   123,
 				"attributes": map[string]interface{}{
 					"some_string": "hello",
 				},
@@ -292,7 +292,7 @@ func TestIteratorSingleObject(t *testing.T) {
 	assert.NoError(t, it.Error())
 
 	assert.True(t, it.Next())
-	assert.Equal(t, "object_id", it.Get().ID())
+	assert.Equal(t, 123, it.Get().ID())
 	assert.False(t, it.Next())
 	assert.Equal(t, "", it.Cursor())
 }


### PR DESCRIPTION
Fixes 'json: cannot unmarshal number into Go struct field objectData.id of type string'


Trying to make use of the api client fails quickly because API types is different.

For example https://github.com/VirusTotal/vt-go/blob/c1b421c1d7eefa7997d0a248528f58b4a529acad/filescan.go#L107 fails because the server returns the following
```json
{
        "id": 1592408668,
        "type": "analysis"
}
```