### PR TITLE
added ability to create client with options, added http client option

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,20 +69,16 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 	}
 }
 
-func NewClientWithOptions(APIKey string, options ...ClientOption) *Client {
-	c := NewClient(APIKey)
+// NewClient creates a new client for interacting with the VirusTotal API using
+// the provided API key.
+func NewClient(APIKey string, opts ...ClientOption) *Client {
+	c := &Client{APIKey: APIKey, httpClient: &http.Client{}}
 
-	for _, o := range options {
+	for _, o := range opts {
 		o(c)
 	}
 
 	return c
-}
-
-// NewClient creates a new client for interacting with the VirusTotal API using
-// the provided API key.
-func NewClient(APIKey string) *Client {
-	return &Client{APIKey: APIKey, httpClient: &http.Client{}}
 }
 
 // sendRequest sends a HTTP request to the VirusTotal REST API.

--- a/client.go
+++ b/client.go
@@ -61,6 +61,24 @@ func opts(opts ...RequestOption) *requestOptions {
 	return o
 }
 
+type ClientOption func(*Client)
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = httpClient
+	}
+}
+
+func NewClientWithOptions(APIKey string, options ...ClientOption) *Client {
+	c := NewClient(APIKey)
+
+	for _, o := range options {
+		o(c)
+	}
+
+	return c
+}
+
 // NewClient creates a new client for interacting with the VirusTotal API using
 // the provided API key.
 func NewClient(APIKey string) *Client {

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 func TestNewClientWithHTTPClientOption(t *testing.T) {
 	httpClient := &http.Client{}
 
-	c := NewClientWithOptions("api-key", WithHTTPClient(httpClient))
+	c := NewClient("api-key", WithHTTPClient(httpClient))
 	if c.httpClient != httpClient {
 		t.Fatalf("failed to set custom http")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,15 @@
+package vt
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewClientWithHTTPClientOption(t *testing.T) {
+	httpClient := &http.Client{}
+
+	c := NewClientWithOptions("api-key", WithHTTPClient(httpClient))
+	if c.httpClient != httpClient {
+		t.Fatalf("failed to set custom http")
+	}
+}


### PR DESCRIPTION
It is unable to set custom http client to control timeouts because of httpClient field is private.
Libraries should provide an api for setting custom http clients.