### PR TITLE
With this change the object.Get method returns json.Number instances …

### DIFF
--- a/vt_test.go
+++ b/vt_test.go
@@ -125,15 +125,15 @@ func TestGetObject(t *testing.T) {
 
 	v, err = o.Get("super.data")
 	assert.NoError(t, err)
-	assert.Equal(t, float64(1), v)
+	assert.Equal(t, json.Number("1"), v)
 
 	v, err = o.Get("super.complex.some_int2")
 	assert.NoError(t, err)
-	assert.Equal(t, float64(1234), v)
+	assert.Equal(t, json.Number("1234"), v)
 
 	v, err = o.Get("some_list.[0].data")
 	assert.NoError(t, err)
-	assert.Equal(t, float64(1), v)
+	assert.Equal(t, json.Number("1"), v)
 
 	assert.ElementsMatch(t,
 		[]string{


### PR DESCRIPTION
…for numeric attributes, instead of float64.

This was the behavior before allowing jsonq paths in the argument for object.Get.