### PR TITLE
feat: Expose object links

### DIFF
--- a/object.go
+++ b/object.go
@@ -117,6 +117,11 @@ func (obj *Object) Relationships() []string {
 	return result
 }
 
+// Links returns the object's links.
+func (obj *Object) Links() *Links {
+	return obj.data.Links
+}
+
 // MarshalJSON marshals a VirusTotal API object.
 func (obj *Object) MarshalJSON() ([]byte, error) {
 	return json.Marshal(obj.data)


### PR DESCRIPTION
Unless I am mistaken, at the moment there are no methods to access the `Links` within an `Object`. This change exposes those links through a new getter method.